### PR TITLE
[2차 피드백, 리펙토링]

### DIFF
--- a/components/common/BaseComponent.js
+++ b/components/common/BaseComponent.js
@@ -1,0 +1,72 @@
+class BaseComponent {
+  $target
+  $props
+  $state
+  $elements // 사용하는 DOM 요소들 (재사용성을 위해 설정)
+
+  constructor($targetOrProps, $props) {
+    /** Modal.js, InlineComponent.js */
+    if (arguments.length === 1) {
+      this.$props = $targetOrProps
+    } else {
+    /** Component.js */
+      this.$target = $targetOrProps
+      this.$props = $props
+    }
+
+    this.setup()
+    this.render()
+    this.setEvent()
+  }
+
+  setup() {}
+
+  /** HTML 템플릿 저장 */
+  template() {
+    return ''
+  }
+
+  /** 컴포넌트에서 필요한 이벤트 설정 */
+  setEvent() {}
+
+  /** 템플릿을 실제 요소로 변환  */
+  render() {}
+
+  /** 자식 컴포넌트 및 요소 정의 */
+  mounted() {}
+
+  setState(newState) {
+    this.$state = { ...this.$state, ...newState }
+    this.render() // UI를 다시 그려서 상태 반영
+  }
+
+  /** CSS 불러오기 */
+  /** TODO: 스타일 없을때 에러처리 */
+  loadStyles(stylePath) {
+    if (!stylePath) return
+
+    // 이미 로드된 스타일인지 확인 (중복 로드 방지)
+    if (document.querySelector(`link[href="${stylePath}"]`)) return
+
+    const link = document.createElement('link')
+    link.rel = 'stylesheet'
+    link.href = stylePath
+    link.setAttribute('data-dynamic-style', stylePath) // 동적 스타일 태그 관리
+    document.head.appendChild(link)
+  }
+
+  /** 이벤트 등록 추상화 */
+  /** 이벤트 등록 추상화 (이제 selector 대신 요소를 직접 받음) */
+  addEvent(element, eventType, callback) {
+    if (!element) {
+      console.error(`❌ 이벤트를 추가할 요소가 존재하지 않습니다.`)
+      return
+    }
+
+    element.addEventListener(eventType, event => {
+      callback(event)
+    })
+  }
+}
+
+export default BaseComponent

--- a/components/common/Button/Button.css
+++ b/components/common/Button/Button.css
@@ -3,9 +3,9 @@
   color: white;
 
   border: none;
-  border-radius: 15px;
+  border-radius: 6px;
 
-  padding: 6px 12px;
+  padding: 8px 18px;
 
   cursor: pointer;
 }

--- a/components/common/Button/Button.js
+++ b/components/common/Button/Button.js
@@ -13,14 +13,19 @@ class Button extends InlineComponent {
     return `<button class='button-component'>${text}</button>`
   }
 
+  mounted() {
+    // DOM 요소 저장
+    // this.$elements = {
+    //   button: 소ㅑㄴ,
+    // }
+    // console.log(this.$elements.button)
+  }
+
   setEvent() {
     const { onClick } = this.$props
 
-    const btn = document.querySelector('.button-component')
-
-    if (btn) {
-      btn.addEventListener('click', () => alert('hello1'))
-    }
+    /** 클릭 이벤트 전달 */
+    this.addEvent('click', this.$target, onClick)
   }
 }
 

--- a/components/common/Button/Button.js
+++ b/components/common/Button/Button.js
@@ -18,7 +18,7 @@ class Button extends InlineComponent {
   setEvent() {
     const { onClick } = this.$props
 
-    this.addEvent('click', this.$target, onClick)
+    this.addEvent(this.$target, 'click', onClick)
   }
 }
 

--- a/components/common/Button/Button.js
+++ b/components/common/Button/Button.js
@@ -13,18 +13,11 @@ class Button extends InlineComponent {
     return `<button class='button-component'>${text}</button>`
   }
 
-  mounted() {
-    // DOM 요소 저장
-    // this.$elements = {
-    //   button: 소ㅑㄴ,
-    // }
-    // console.log(this.$elements.button)
-  }
+  mounted() {}
 
   setEvent() {
     const { onClick } = this.$props
 
-    /** 클릭 이벤트 전달 */
     this.addEvent('click', this.$target, onClick)
   }
 }

--- a/components/common/Component.js
+++ b/components/common/Component.js
@@ -26,7 +26,7 @@ class Component {
 
   /** 이벤트 등록 추상화 */
   /** 이벤트 등록 추상화 (이제 selector 대신 요소를 직접 받음) */
-  addEvent(eventType, element, callback) {
+  addEvent(element, eventType, callback) {
     if (!element) {
       console.error(`❌ 이벤트를 추가할 요소가 존재하지 않습니다.`)
       return

--- a/components/common/Component.js
+++ b/components/common/Component.js
@@ -1,68 +1,9 @@
-class Component {
-  $target
-  $props
-  $state
-  $elements // 사용하는 DOM 요소들 (재사용성을 위해 설정)
+import BaseComponent from './BaseComponent.js'
 
-  /** 컴포넌트가 표시될 타겟 지정 */
-  constructor($target, $props) {
-    this.$target = $target
-    this.$props = $props
-
-    this.setup()
-    this.render()
-    this.setEvent()
-  }
-
-  /** 상태 정의 및 기본값 저장 */
-  setup() {}
-
-  /** HTML 템플릿 저장 */
-  template() {
-    return ''
-  }
-
-  setEvent() {}
-
-  /** 이벤트 등록 추상화 */
-  /** 이벤트 등록 추상화 (이제 selector 대신 요소를 직접 받음) */
-  addEvent(element, eventType, callback) {
-    if (!element) {
-      console.error(`❌ 이벤트를 추가할 요소가 존재하지 않습니다.`)
-      return
-    }
-
-    element.addEventListener(eventType, event => {
-      callback(event)
-    })
-  }
-
+class Component extends BaseComponent {
   render() {
     this.$target.innerHTML = this.template() //UI 렌더링
     this.mounted()
-  }
-
-  /** 자식 컴포넌트 및 요소 정의 */
-  mounted() {}
-
-  setState(newState) {
-    this.state = { ...this.state, ...newState }
-    this.render()
-  }
-
-  /** CSS 불러오기 */
-  /** TODO: 스타일 없을때 에러처리 */
-  loadStyles(stylePath) {
-    if (!stylePath) return
-
-    // 이미 로드된 스타일인지 확인 (중복 로드 방지)
-    if (document.querySelector(`link[href="${stylePath}"]`)) return
-
-    const link = document.createElement('link')
-    link.rel = 'stylesheet'
-    link.href = stylePath
-    link.setAttribute('data-dynamic-style', stylePath) // 동적 스타일 태그 관리
-    document.head.appendChild(link)
   }
 }
 

--- a/components/common/Header/Header.js
+++ b/components/common/Header/Header.js
@@ -78,28 +78,28 @@ class Header extends Component {
 
   setEvent() {
     /** 프로필 이미지 클릭 이벤트  */
-    this.addEvent('click', this.$elements.Image, this.toggleDropdownMenu.bind(this))
+    this.addEvent(this.$elements.Image, 'click', this.toggleDropdownMenu.bind(this))
 
     // TODO: 외부 클릭 시 메뉴 닫기
     // DropdownMenu.addEventListener("click", outsideClick);
-    // this.addEvent("click", "#dropdown-menu", outsideClick);
+    // this.addEvent( "#dropdown-menu", "click",outsideClick);
 
-    this.addEvent('click', this.$elements.mypageLink, event => {
+    this.addEvent(this.$elements.mypageLink, 'click', event => {
       navigateTo(ROUTES.AUTH.MYPAGE.url)
     })
-    this.addEvent('click', this.$elements.passwordChangeLink, event => {
+    this.addEvent(this.$elements.passwordChangeLink, 'click', event => {
       navigateTo(ROUTES.AUTH.PASSWORD_CHANGE.url)
     })
 
     // TODO: 로그아웃 로직 이벤트 구현
-    this.addEvent('click', this.$elements.logoutLink, event => {
+    this.addEvent(this.$elements.logoutLink, 'click', event => {
       alert('로그아웃 성공')
 
       // navigateTo(ROUTES.AUTH.PASSWORD_CHANGE.url);
     })
 
     if (this.$state.backRoute) {
-      this.addEvent('click', this.$elements.backButton, event => {
+      this.addEvent(this.$elements.backButton, 'click', event => {
         navigateTo(this.$state.backRoute)
       })
     }

--- a/components/common/InlineComponent.js
+++ b/components/common/InlineComponent.js
@@ -1,41 +1,6 @@
-class InlineComponent {
-  $target
-  $props
-  $state
-  $elements // 사용하는 DOM 요소들 (재사용성을 위해 설정)
+import BaseComponent from './BaseComponent.js'
 
-  constructor($target, $props) {
-    this.$target = $target
-    this.$props = $props
-
-    this.setup()
-    this.render()
-    this.setEvent()
-  }
-
-  setup() {}
-
-  /** HTML 템플릿 저장 */
-  template() {
-    return ''
-  }
-
-  /** 컴포넌트에서 필요한 이벤트 설정 */
-  setEvent() {}
-
-  /** 이벤트 등록 추상화 */
-  /** 이벤트 등록 추상화 (이제 selector 대신 요소를 직접 받음) */
-  addEvent(element, eventType, callback) {
-    if (!element) {
-      console.error(`❌ 이벤트를 추가할 요소가 존재하지 않습니다.`)
-      return
-    }
-
-    element.addEventListener(eventType, event => {
-      callback(event)
-    })
-  }
-
+class InlineComponent extends BaseComponent {
   /** 템플릿을 실제 요소로 변환  */
   render() {
     const wrapper = document.createElement('div') // 임시 래퍼 요소
@@ -56,27 +21,6 @@ class InlineComponent {
     }
 
     this.mounted() // mounted() 실행
-  }
-
-  /** 자식 컴포넌트 및 요소 정의 */
-  mounted() {}
-
-  setState(newState) {
-    this.$state = { ...this.$state, ...newState }
-    this.render() // UI를 다시 그려서 상태 반영
-  }
-
-  /** CSS 불러오기 */
-  /** TODO: 스타일 없을때 에러처리 */
-  loadStyles(stylePath) {
-    if (!stylePath) return
-    if (document.querySelector(`link[href="${stylePath}"]`)) return
-
-    const link = document.createElement('link')
-    link.rel = 'stylesheet'
-    link.href = stylePath
-    link.setAttribute('data-dynamic-style', stylePath) // 동적 스타일 태그 관리
-    document.head.appendChild(link)
   }
 
   /**

--- a/components/common/InlineComponent.js
+++ b/components/common/InlineComponent.js
@@ -25,7 +25,7 @@ class InlineComponent {
 
   /** 이벤트 등록 추상화 */
   /** 이벤트 등록 추상화 (이제 selector 대신 요소를 직접 받음) */
-  addEvent(eventType, element, callback) {
+  addEvent(element, eventType, callback) {
     if (!element) {
       console.error(`❌ 이벤트를 추가할 요소가 존재하지 않습니다.`)
       return

--- a/components/common/Modal/Modal.css
+++ b/components/common/Modal/Modal.css
@@ -54,12 +54,12 @@
   cursor: pointer;
 }
 
-.modal-cancel {
+#modal-cancel {
   background: black;
   color: white;
 }
 
-.modal-confirm {
+#modal-confirm {
   background: #bca0ff;
   color: white;
 }

--- a/components/common/Modal/Modal.js
+++ b/components/common/Modal/Modal.js
@@ -1,6 +1,7 @@
-import InlineComponent from '../InlineComponent.js'
+import Button from '../Button/Button.js'
+import PortalComponent from '../PortalComponent.js'
 
-class Modal extends InlineComponent {
+class Modal extends PortalComponent {
   setup() {
     this.loadStyles()
   }
@@ -17,8 +18,8 @@ class Modal extends InlineComponent {
           <p class="modal-title">${title}</p>
           <p class="modal-message">${message}</p>
           <div class="modal-buttons">
-            <button class="modal-cancel">${cancelText || '취소'}</button>
-            <button class="modal-confirm">${confirmText || '확인'}</button>
+            <button id="modal-cancel"></button>
+            <button id="modal-confirm"></button>
           </div>
         </div>
       </div>
@@ -32,25 +33,29 @@ class Modal extends InlineComponent {
 
     // DOM 요소 저장
     this.$elements = {
-      modalElement: this.$target.querySelector('.modal-overlay'),
-      cancelButton: this.$target.querySelector('.modal-cancel'),
-      confirmButton: this.$target.querySelector('.modal-confirm'),
+      cancelButton: this.$target.querySelector('#modal-cancel'),
+      confirmButton: this.$target.querySelector('#modal-confirm'),
     }
-  }
 
-  setEvent() {
-    const { onConfirm, onCancel } = this.$props
+    // 자식 요소 정의
+    const { confirmText, cancelText } = this.$props
 
-    this.$elements.cancelButton.addEventListener('click', () => {
-      if (onCancel) onCancel()
-      this.close()
+    console.log(this.$elements.cancelButton)
+
+    new Button(this.$elements.cancelButton, {
+      text: cancelText || '취소',
+      onClick: this.cancelHandler.bind(this),
+      idName: 'modal-cancel',
     })
 
-    this.$elements.confirmButton.addEventListener('click', () => {
-      if (onConfirm) onConfirm()
-      this.close()
+    new Button(this.$elements.confirmButton, {
+      text: confirmText || '확인',
+      onClick: this.confirmHandler.bind(this),
+      idName: 'modal-confirm',
     })
   }
+
+  setEvent() {}
 
   close() {
     if (this.$target) {
@@ -58,6 +63,20 @@ class Modal extends InlineComponent {
 
       document.body.style.overflow = '' // 스크롤 다시 가능
     }
+  }
+
+  cancelHandler() {
+    const { onCancel } = this.$props
+
+    if (onCancel) onCancel()
+    this.close()
+  }
+
+  confirmHandler() {
+    const { onConfirm } = this.$props
+
+    if (this.$props.onConfirm) onConfirm()
+    this.close()
   }
 }
 

--- a/components/common/Modal/Modal.js
+++ b/components/common/Modal/Modal.js
@@ -40,8 +40,6 @@ class Modal extends PortalComponent {
     // 자식 요소 정의
     const { confirmText, cancelText } = this.$props
 
-    console.log(this.$elements.cancelButton)
-
     new Button(this.$elements.cancelButton, {
       text: cancelText || '취소',
       onClick: this.cancelHandler.bind(this),

--- a/components/common/PortalComponent.js
+++ b/components/common/PortalComponent.js
@@ -1,26 +1,6 @@
-class PortalComponent {
-  $target
-  $props
-  $state
-  $elements // 사용하는 DOM 요소들 (재사용성을 위해 설정)
+import BaseComponent from './BaseComponent.js'
 
-  constructor($props) {
-    this.$props = $props
-    this.setup()
-    this.render()
-    this.setEvent()
-  }
-
-  setup() {}
-
-  /** HTML 템플릿 저장 */
-  template() {
-    return ''
-  }
-
-  /** 컴포넌트에서 필요한 이벤트 설정 */
-  setEvent() {}
-
+class PortalComponent extends BaseComponent {
   /** 템플릿을 실제 요소로 변환  */
   render() {
     const wrapper = document.createElement('div') // 임시 요소
@@ -30,26 +10,6 @@ class PortalComponent {
     if (!this.$target) return
 
     this.mounted()
-  }
-
-  /** 자식 컴포넌트 및 요소 정의 */
-  mounted() {}
-
-  setState(newState) {
-    this.$state = { ...this.$state, ...newState }
-    this.render() // UI를 다시 그려서 상태 반영
-  }
-
-  /** CSS 불러오기 */
-  /** TODO: 스타일 없을때 에러처리 */
-  loadStyles(stylePath) {
-    if (!stylePath) return
-    if (document.querySelector(`link[href="${stylePath}"]`)) return
-
-    const link = document.createElement('link')
-    link.rel = 'stylesheet'
-    link.href = stylePath
-    document.head.appendChild(link)
   }
 
   /**

--- a/components/common/PortalComponent.js
+++ b/components/common/PortalComponent.js
@@ -1,13 +1,11 @@
-class InlineComponent {
+class PortalComponent {
   $target
   $props
   $state
   $elements // 사용하는 DOM 요소들 (재사용성을 위해 설정)
 
-  constructor($target, $props) {
-    this.$target = $target
+  constructor($props) {
     this.$props = $props
-
     this.setup()
     this.render()
     this.setEvent()
@@ -23,39 +21,15 @@ class InlineComponent {
   /** 컴포넌트에서 필요한 이벤트 설정 */
   setEvent() {}
 
-  /** 이벤트 등록 추상화 */
-  /** 이벤트 등록 추상화 (이제 selector 대신 요소를 직접 받음) */
-  addEvent(eventType, element, callback) {
-    if (!element) {
-      console.error(`❌ 이벤트를 추가할 요소가 존재하지 않습니다.`)
-      return
-    }
-
-    element.addEventListener(eventType, event => {
-      callback(event)
-    })
-  }
-
   /** 템플릿을 실제 요소로 변환  */
   render() {
-    const wrapper = document.createElement('div') // 임시 래퍼 요소
+    const wrapper = document.createElement('div') // 임시 요소
     wrapper.innerHTML = this.template().trim()
+    this.$target = wrapper.firstChild
 
-    const newComponent = wrapper.firstElementChild // 첫 번째 자식 요소를 가져옴
-    if (!newComponent) return
+    if (!this.$target) return
 
-    this.$target.replaceWith(newComponent)
-    this.$target = newComponent
-    // id 속성 추가
-    if (this.$props?.idName) {
-      this.$target.id = this.$props.idName
-    }
-    // class 속성 추가
-    if (this.$props?.className) {
-      this.$target.classList.add(...this.$props.className.split(' '))
-    }
-
-    this.mounted() // mounted() 실행
+    this.mounted()
   }
 
   /** 자식 컴포넌트 및 요소 정의 */
@@ -75,7 +49,6 @@ class InlineComponent {
     const link = document.createElement('link')
     link.rel = 'stylesheet'
     link.href = stylePath
-    link.setAttribute('data-dynamic-style', stylePath) // 동적 스타일 태그 관리
     document.head.appendChild(link)
   }
 
@@ -88,4 +61,4 @@ class InlineComponent {
   }
 }
 
-export default InlineComponent
+export default PortalComponent

--- a/components/common/Toast/Toast.js
+++ b/components/common/Toast/Toast.js
@@ -2,8 +2,6 @@ import PortalComponent from '../PortalComponent.js'
 
 class Toast extends PortalComponent {
   setup() {
-    console.log(this.$props)
-
     this.$state = {
       clearTimeout: this.$props.clearTimeout,
     }
@@ -27,7 +25,6 @@ class Toast extends PortalComponent {
     this.$elements = {
       toasts: document.getElementsByClassName('toast'),
     }
-    console.log(this.$elements)
   }
 
   setEvent() {

--- a/components/common/Toast/Toast.js
+++ b/components/common/Toast/Toast.js
@@ -1,7 +1,9 @@
-import InlineComponent from '../InlineComponent.js'
+import PortalComponent from '../PortalComponent.js'
 
-class Toast extends InlineComponent {
+class Toast extends PortalComponent {
   setup() {
+    console.log(this.$props)
+
     this.$state = {
       clearTimeout: this.$props.clearTimeout,
     }
@@ -25,6 +27,7 @@ class Toast extends InlineComponent {
     this.$elements = {
       toasts: document.getElementsByClassName('toast'),
     }
+    console.log(this.$elements)
   }
 
   setEvent() {

--- a/pages/auth/Login.js
+++ b/pages/auth/Login.js
@@ -69,16 +69,16 @@ class Login extends Component {
   }
 
   setEvent() {
-    this.addEvent('input', this.$elements.emailInput, event => {
+    this.addEvent(this.$elements.emailInput, 'input', event => {
       this.validateEmail()
       this.validateForm()
     })
-    this.addEvent('input', this.$elements.passwordInput, event => {
+    this.addEvent(this.$elements.passwordInput, 'input', event => {
       this.validatePassword()
       this.validateForm()
     })
-    this.addEvent('click', this.$elements.loginButton, this.loginHandler.bind(this))
-    this.addEvent('click', this.$elements.registerButton, this.navigateToRegister.bind(this))
+    this.addEvent(this.$elements.loginButton, 'click', this.loginHandler.bind(this))
+    this.addEvent(this.$elements.registerButton, 'click', this.navigateToRegister.bind(this))
   }
 
   /** 이메일 유효성 검사 */

--- a/pages/auth/Login.js
+++ b/pages/auth/Login.js
@@ -57,13 +57,13 @@ class Login extends Component {
     // 자식 요소 정의
     new Button(this.$elements.loginButton, {
       text: '로그인',
-      onClick: this.loginRoute.bind(this),
+      onClick: this.loginHandler.bind(this),
       idName: 'login-button',
     })
 
     new Button(this.$elements.registerButton, {
       text: '회원가입',
-      onClick: this.registerRoute.bind(this),
+      onClick: this.navigateToRegister.bind(this),
       idName: 'register-button',
     })
   }
@@ -77,8 +77,8 @@ class Login extends Component {
       this.validatePassword()
       this.validateForm()
     })
-    this.addEvent('click', this.$elements.loginButton, this.loginRoute.bind(this))
-    this.addEvent('click', this.$elements.registerButton, this.registerRoute.bind(this))
+    this.addEvent('click', this.$elements.loginButton, this.loginHandler.bind(this))
+    this.addEvent('click', this.$elements.registerButton, this.navigateToRegister.bind(this))
   }
 
   /** 이메일 유효성 검사 */
@@ -105,13 +105,12 @@ class Login extends Component {
       loginButton.disabled = false // 버튼 활성화
     }
   }
-
-  loginRoute() {
-    // TODO: 로그인 API 필요 (현재는 더미 데이터 확인 후 로그인)
+  // TODO: 로그인 API 필요 (현재는 더미 데이터 확인 후 로그인)
+  loginHandler() {
     navigateTo(ROUTES.POST.MAIN.url)
   }
 
-  registerRoute() {
+  navigateToRegister() {
     navigateTo(ROUTES.AUTH.REGISTER.url)
   }
 }

--- a/pages/auth/Login.js
+++ b/pages/auth/Login.js
@@ -1,3 +1,4 @@
+import Button from '../../components/common/Button/Button.js'
 import Component from '../../components/common/Component.js'
 import { validateEmailInput, validatePasswordInput } from '../../lib/validation/inputValidations.js'
 import { ROUTES } from '../../public/data/routes.js'
@@ -36,8 +37,8 @@ class Login extends Component {
           <div class="error-message" id="password-error-message"></div>
         </form>
 
-        <button id="login-button">로그인</button>
-        <button id="register-button">회원가입</button>
+        <button id="login-button"></button>
+        <button id="register-button"></button>
       </main>
       `
   }
@@ -52,6 +53,19 @@ class Login extends Component {
       loginButton: this.$target.querySelector('#login-button'),
       registerButton: this.$target.querySelector('#register-button'),
     }
+
+    // 자식 요소 정의
+    new Button(this.$elements.loginButton, {
+      text: '로그인',
+      onClick: this.loginRoute.bind(this),
+      idName: 'login-button',
+    })
+
+    new Button(this.$elements.registerButton, {
+      text: '회원가입',
+      onClick: this.registerRoute.bind(this),
+      idName: 'register-button',
+    })
   }
 
   setEvent() {

--- a/pages/auth/Mypage.js
+++ b/pages/auth/Mypage.js
@@ -1,3 +1,4 @@
+import Button from '../../components/common/Button/Button.js'
 import Component from '../../components/common/Component.js'
 import Modal from '../../components/common/Modal/Modal.js'
 import Toast from '../../components/common/Toast/Toast.js'
@@ -44,11 +45,11 @@ class Mypage extends Component {
             placeholder="닉네임을 입력하세요"
           />
           <div class="error-message" id="nickname-error">* helper text</div>
-          <button id="modify-button">수정하기</button>
+          <button id="modify-button"></button>
         </div>
       </form>
 
-      <button id="unregister-button">회원 탈퇴</button>
+      <button id="unregister-button"></button>
     </main>`
   }
 
@@ -59,14 +60,25 @@ class Mypage extends Component {
       nicknameErrorText: this.$target.querySelector('#nickname-error'),
       modifyButton: this.$target.querySelector('#modify-button'),
       unregisterButton: this.$target.querySelector('#unregister-button'),
-      unConfirmButton: this.$target.querySelector('#cancel-button'),
+      unconfirmButton: this.$target.querySelector('#cancel-button'),
     }
+
+    // 자식 요소 정의
+    new Button(this.$elements.modifyButton, {
+      text: '수정하기',
+      onClick: this.modifyHandler.bind(this),
+      idName: 'modify-button',
+    })
+
+    new Button(this.$elements.unregisterButton, {
+      text: '회원 탈퇴',
+      onClick: this.unregisterHandler.bind(this),
+      idName: 'unregister-button',
+    })
   }
 
   setEvent() {
-    this.addEvent('click', this.$elements.modifyButton, this.modifyHandler.bind(this))
     this.addEvent('input', this.$elements.nicknameInput, this.validateNickname.bind(this))
-    this.addEvent('click', this.$elements.unregisterButton, this.unregisterHandler.bind(this))
   }
 
   /** 닉네임 유효성 검사 */
@@ -86,6 +98,8 @@ class Mypage extends Component {
 
   /** 회원탈퇴 로직 */
   unregisterHandler() {
+    console.log('enetered')
+
     new Modal({
       title: '회원탈퇴 하시겠습니까?',
       message: '작성된 게시글과 댓글은 삭제됩니다.',

--- a/pages/auth/Mypage.js
+++ b/pages/auth/Mypage.js
@@ -98,8 +98,6 @@ class Mypage extends Component {
 
   /** 회원탈퇴 로직 */
   unregisterHandler() {
-    console.log('enetered')
-
     new Modal({
       title: '회원탈퇴 하시겠습니까?',
       message: '작성된 게시글과 댓글은 삭제됩니다.',

--- a/pages/auth/Mypage.js
+++ b/pages/auth/Mypage.js
@@ -78,7 +78,7 @@ class Mypage extends Component {
   }
 
   setEvent() {
-    this.addEvent('input', this.$elements.nicknameInput, this.validateNickname.bind(this))
+    this.addEvent(this.$elements.nicknameInput, 'input', this.validateNickname.bind(this))
   }
 
   /** 닉네임 유효성 검사 */

--- a/pages/auth/PasswordChange.js
+++ b/pages/auth/PasswordChange.js
@@ -1,3 +1,4 @@
+import Button from '../../components/common/Button/Button.js'
 import Component from '../../components/common/Component.js'
 import Toast from '../../components/common/Toast/Toast.js'
 import { validatePasswordConfirmInput, validatePasswordInput } from '../../lib/validation/inputValidations.js'
@@ -40,7 +41,7 @@ class PasswordChange extends Component {
           </div>
           
 
-          <button id="submit-button">수정하기</button>
+          <button id="submit-button"></button>
         </form>
       </main>
     `
@@ -62,6 +63,13 @@ class PasswordChange extends Component {
       // 버튼 요소
       submitButton: this.$target.querySelector('#submit-button'),
     }
+
+    // 자식 요소 정의
+    new Button(this.$elements.submitButton, {
+      text: '수정하기',
+      onClick: this.modifyHandler.bind(this),
+      idName: 'submit-button',
+    })
   }
 
   setEvent() {
@@ -73,7 +81,6 @@ class PasswordChange extends Component {
       this.validatePasswordConfirm()
       this.validateForm()
     })
-    this.addEvent('click', this.$elements.submitButton, this.modifyHandler.bind(this))
   }
 
   /** 비밀번호 유효성 검사 */

--- a/pages/auth/PasswordChange.js
+++ b/pages/auth/PasswordChange.js
@@ -73,11 +73,11 @@ class PasswordChange extends Component {
   }
 
   setEvent() {
-    this.addEvent('input', this.$elements.passwordInput, event => {
+    this.addEvent(this.$elements.passwordInput, 'input', event => {
       this.validatePassword()
       this.validateForm()
     })
-    this.addEvent('input', this.$elements.passwordConfirmInput, event => {
+    this.addEvent(this.$elements.passwordConfirmInput, 'input', event => {
       this.validatePasswordConfirm()
       this.validateForm()
     })

--- a/pages/auth/Register.js
+++ b/pages/auth/Register.js
@@ -1,3 +1,4 @@
+import Button from '../../components/common/Button/Button.js'
 import Component from '../../components/common/Component.js'
 import {
   validateEmailInput,
@@ -79,10 +80,10 @@ class Register extends Component {
             <div class="error-message" id="nickname-error">* helper text</div>
           </div>
 
-          <button id="register-button">회원가입</button>
+          <button id="register-button"></button>
         </form>
 
-        <button id="login-button">로그인하러 가기</button>
+        <button id="login-button"></button>
       </main>
     `
   }
@@ -113,6 +114,18 @@ class Register extends Component {
       registerButton: this.$target.querySelector('#register-button'),
       loginButton: this.$target.querySelector('#login-button'),
     }
+
+    // 자식 요소 정의
+    new Button(this.$elements.registerButton, {
+      text: '회원가입',
+      onClick: this.registerHandler.bind(this),
+      idName: 'register-button',
+    })
+    new Button(this.$elements.loginButton, {
+      text: '로그인하러 가기',
+      onClick: this.loginRouteHandler.bind(this),
+      idName: 'login-button',
+    })
   }
 
   setEvent() {
@@ -140,10 +153,6 @@ class Register extends Component {
       this.validateNickname()
       this.validateForm()
     })
-
-    // 클릭 이벤트
-    this.addEvent('click', this.$elements.registerButton, this.registerHandler.bind(this))
-    this.addEvent('click', this.$elements.loginButton, this.loginRouteHandler.bind(this))
   }
 
   // 이미지가 입력받아지면 수행할 일
@@ -156,7 +165,7 @@ class Register extends Component {
     if (profileInput.files && profileInput.files[0]) {
       const reader = new FileReader()
       reader.onload = function (e) {
-        profileImage.src = e.target.result
+        profileImage.src = e.target?.result
         profileImage.style.display = 'block'
         profilePlaceholder.style.display = 'none'
       }

--- a/pages/auth/Register.js
+++ b/pages/auth/Register.js
@@ -123,7 +123,7 @@ class Register extends Component {
     })
     new Button(this.$elements.loginButton, {
       text: '로그인하러 가기',
-      onClick: this.loginRouteHandler.bind(this),
+      onClick: this.navigateToLoginRoute.bind(this),
       idName: 'login-button',
     })
   }
@@ -253,12 +253,12 @@ class Register extends Component {
     }
   }
 
-  loginRouteHandler() {
+  navigateToLoginRoute() {
     navigateTo(ROUTES.AUTH.LOGIN.url)
   }
 
+  /** TODO: 회원가입 로직 구현 필요 */
   registerHandler() {
-    /** TODO: 회원가입 로직 구현 필요 */
     navigateTo(ROUTES.AUTH.LOGIN.url)
   }
 }

--- a/pages/auth/Register.js
+++ b/pages/auth/Register.js
@@ -129,27 +129,27 @@ class Register extends Component {
   }
 
   setEvent() {
-    this.addEvent('input', this.$elements.profileInput, event => {
+    this.addEvent(this.$elements.profileInput, 'input', event => {
       this.validateProfile()
       this.validateForm()
     })
-    this.addEvent('change', this.$elements.profileInput, this.profileChangeHandler.bind(this))
+    this.addEvent(this.$elements.profileInput, 'change', this.profileChangeHandler.bind(this))
 
-    this.addEvent('click', this.$elements.profilePreview, this.getProfileImage.bind(this))
+    this.addEvent(this.$elements.profilePreview, 'click', this.getProfileImage.bind(this))
     // 입력 이벤트
-    this.addEvent('input', this.$elements.emailInput, event => {
+    this.addEvent(this.$elements.emailInput, 'input', event => {
       this.validateEmail()
       this.validateForm()
     })
-    this.addEvent('input', this.$elements.passwordInput, event => {
+    this.addEvent(this.$elements.passwordInput, 'input', event => {
       this.validatePassword()
       this.validateForm()
     })
-    this.addEvent('input', this.$elements.passwordConfirmInput, event => {
+    this.addEvent(this.$elements.passwordConfirmInput, 'input', event => {
       this.validatePasswordConfirm()
       this.validateForm()
     })
-    this.addEvent('input', this.$elements.nicknameInput, event => {
+    this.addEvent(this.$elements.nicknameInput, 'input', event => {
       this.validateNickname()
       this.validateForm()
     })

--- a/pages/post/PostDetail.js
+++ b/pages/post/PostDetail.js
@@ -1,3 +1,4 @@
+import Button from '../../components/common/Button/Button.js'
 import Component from '../../components/common/Component.js'
 import Modal from '../../components/common/Modal/Modal.js'
 import { formatNumber } from '../../lib/utils/number.js'
@@ -22,8 +23,8 @@ class PostDetail extends Component {
           <span class="time">2021-01-01 00:00:00</span>
 
           <div class="buttons" id="header-buttons">
-            <button id="modify-post">수정</button>
-            <button id="delete-post">삭제</button>
+            <button id="modify-post"></button>
+            <button id="delete-post"></button>
           </div>
         </div>
       </section>
@@ -55,7 +56,7 @@ class PostDetail extends Component {
 
       <section id="comment-box">
         <textarea placeholder="댓글을 남겨주세요!" id="comment-input"></textarea>
-        <button id="comment-button">댓글 등록</button>
+        <button id="comment-button"></button>
       </section>
 
       <section id="comment-list">
@@ -72,8 +73,8 @@ class PostDetail extends Component {
           </div>
           
           <div class="buttons" id="comment-buttons">
-            <button id="comment-modify">수정</button>
-            <button id="comment-delete">삭제</button>
+            <button class="comment-modify"></button>
+            <button class="comment-delete"></button>
           </div>
         </div>
 
@@ -90,8 +91,8 @@ class PostDetail extends Component {
           </div>
           
           <div class="buttons" id="comment-buttons">
-            <button id="comment-modify">수정</button>
-            <button id="comment-delete">삭제</button>
+            <button class="comment-modify"></button>
+            <button class="comment-delete"></button>
           </div>
         </div>
 
@@ -108,8 +109,8 @@ class PostDetail extends Component {
           </div>
           
           <div class="buttons" id="comment-buttons">
-            <button id="comment-modify">수정</button>
-            <button id="comment-delete">삭제</button>
+            <button class="comment-modify"></button>
+            <button class="comment-delete"></button>
           </div>
         </div>
       </section>
@@ -121,20 +122,60 @@ class PostDetail extends Component {
     this.$elements = {
       modifyPostButton: this.$target.querySelector('#modify-post'),
       deletePostButton: this.$target.querySelector('#delete-post'),
-      commentInput: this.$target.querySelector('#comment-input'),
-      commentAddButton: this.$target.querySelector('#comment-button'),
 
-      commentDeleteButton: this.$target.querySelector('#comment-delete'),
+      commentInput: this.$target.querySelector('#comment-input'),
+
+      commentAddButton: this.$target.querySelector('#comment-button'),
+      commentModifyButtons: [...this.$target.querySelectorAll('.comment-modify')],
+      commentDeleteButtons: [...this.$target.querySelectorAll('.comment-delete')],
     }
+
+    console.log([...this.$target.querySelectorAll('.comment-modify')])
+    console.log(this.$elements.commentModifyButtons)
+
+    // 자식 요소 정의
+    new Button(this.$elements.modifyPostButton, {
+      text: '수정',
+      onClick: this.modifyPost.bind(this),
+      idName: 'modify-post',
+    })
+    new Button(this.$elements.deletePostButton, {
+      text: '삭제',
+      onClick: this.deletePost.bind(this),
+      idName: 'delete-post',
+    })
+    console.log(this.$elements.commentAddButton)
+
+    new Button(this.$elements.commentAddButton, {
+      text: '댓글 등록',
+      onClick: this.postComment.bind(this),
+      idName: 'comment-button',
+    })
+
+    // TODO: 댓글 수정 로직 구현
+    // 모든 댓글 수정 버튼에 대해 Button 컴포넌트 생성
+    this.$elements.commentModifyButtons.forEach((button, index) => {
+      new Button(button, {
+        text: '수정',
+        onClick: this.modifyComment.bind(this),
+        className: 'comment-modify',
+      })
+    })
+
+    // 모든 댓글 삭제 버튼에 대해 Button 컴포넌트 생성
+    this.$elements.commentDeleteButtons.forEach((button, index) => {
+      console.log('요소: ', button)
+
+      new Button(button, {
+        text: '삭제',
+        onClick: this.deleteComment.bind(this),
+        className: 'comment-delete',
+      })
+    })
   }
 
   setEvent() {
-    this.addEvent('click', this.$elements.modifyPostButton, this.modifyPost.bind(this))
-    this.addEvent('click', this.$elements.deletePostButton, this.deletePost.bind(this))
-
     this.addEvent('input', this.$elements.commentInput, this.commentChange.bind(this))
-    this.addEvent('click', this.$elements.commentAddButton, this.postComment.bind(this))
-    this.addEvent('click', this.$elements.commentDeleteButton, this.deleteComment.bind(this))
   }
 
   modifyPost() {
@@ -178,7 +219,12 @@ class PostDetail extends Component {
     }
   }
 
-  postComment() {}
+  postComment() {
+    alert('Post Comment')
+  }
+  modifyComment() {
+    alert('Modify Comment')
+  }
 
   deleteComment() {
     new Modal({

--- a/pages/post/PostDetail.js
+++ b/pages/post/PostDetail.js
@@ -136,19 +136,19 @@ class PostDetail extends Component {
     // 자식 요소 정의
     new Button(this.$elements.modifyPostButton, {
       text: '수정',
-      onClick: this.modifyPost.bind(this),
+      onClick: this.navigateToModifyPost.bind(this),
       idName: 'modify-post',
     })
     new Button(this.$elements.deletePostButton, {
       text: '삭제',
-      onClick: this.deletePost.bind(this),
+      onClick: this.deletePostHandler.bind(this),
       idName: 'delete-post',
     })
     console.log(this.$elements.commentAddButton)
 
     new Button(this.$elements.commentAddButton, {
       text: '댓글 등록',
-      onClick: this.postComment.bind(this),
+      onClick: this.postCommentHandler.bind(this),
       idName: 'comment-button',
     })
 
@@ -157,7 +157,7 @@ class PostDetail extends Component {
     this.$elements.commentModifyButtons.forEach((button, index) => {
       new Button(button, {
         text: '수정',
-        onClick: this.modifyComment.bind(this),
+        onClick: this.modifyCommentHandler.bind(this),
         className: 'comment-modify',
       })
     })
@@ -168,22 +168,22 @@ class PostDetail extends Component {
 
       new Button(button, {
         text: '삭제',
-        onClick: this.deleteComment.bind(this),
+        onClick: this.deleteCommentHandler.bind(this),
         className: 'comment-delete',
       })
     })
   }
 
   setEvent() {
-    this.addEvent('input', this.$elements.commentInput, this.commentChange.bind(this))
+    this.addEvent('input', this.$elements.commentInput, this.inputCommentHandler.bind(this))
   }
 
-  modifyPost() {
-    // TODO: 게시글 수정 라우팅 구현 (데이터도 같이 전송)
+  // TODO: 게시글 수정 라우팅 구현 (데이터도 같이 전송)
+  navigateToModifyPost() {
     navigateTo(ROUTES.POST.MODIFY.url)
   }
 
-  deletePost() {
+  deletePostHandler() {
     new Modal({
       title: '게시글을 삭제하시겠습니까?',
       message: '삭제한 내용은 복구 할 수 없습니다.',
@@ -196,7 +196,7 @@ class PostDetail extends Component {
     })
   }
 
-  commentChange() {
+  inputCommentHandler() {
     const comment = this.$elements.commentInput
     const commentAddButton = this.$elements.commentAddButton
 
@@ -219,14 +219,14 @@ class PostDetail extends Component {
     }
   }
 
-  postComment() {
+  postCommentHandler() {
     alert('Post Comment')
   }
-  modifyComment() {
+  modifyCommentHandler() {
     alert('Modify Comment')
   }
 
-  deleteComment() {
+  deleteCommentHandler() {
     new Modal({
       title: '댓글을 삭제하시겠습니까?',
       message: '삭제한 내용은 복구 할 수 없습니다.',

--- a/pages/post/PostDetail.js
+++ b/pages/post/PostDetail.js
@@ -130,9 +130,6 @@ class PostDetail extends Component {
       commentDeleteButtons: [...this.$target.querySelectorAll('.comment-delete')],
     }
 
-    console.log([...this.$target.querySelectorAll('.comment-modify')])
-    console.log(this.$elements.commentModifyButtons)
-
     // 자식 요소 정의
     new Button(this.$elements.modifyPostButton, {
       text: '수정',
@@ -144,7 +141,6 @@ class PostDetail extends Component {
       onClick: this.deletePostHandler.bind(this),
       idName: 'delete-post',
     })
-    console.log(this.$elements.commentAddButton)
 
     new Button(this.$elements.commentAddButton, {
       text: '댓글 등록',
@@ -164,8 +160,6 @@ class PostDetail extends Component {
 
     // 모든 댓글 삭제 버튼에 대해 Button 컴포넌트 생성
     this.$elements.commentDeleteButtons.forEach((button, index) => {
-      console.log('요소: ', button)
-
       new Button(button, {
         text: '삭제',
         onClick: this.deleteCommentHandler.bind(this),

--- a/pages/post/PostDetail.js
+++ b/pages/post/PostDetail.js
@@ -175,7 +175,7 @@ class PostDetail extends Component {
   }
 
   setEvent() {
-    this.addEvent('input', this.$elements.commentInput, this.inputCommentHandler.bind(this))
+    this.addEvent(this.$elements.commentInput, 'input', this.inputCommentHandler.bind(this))
   }
 
   // TODO: 게시글 수정 라우팅 구현 (데이터도 같이 전송)

--- a/pages/post/PostList.js
+++ b/pages/post/PostList.js
@@ -70,12 +70,12 @@ class PostList extends Component {
     // 자식 요소 정의
     new Button(this.$elements.writePostButton, {
       text: '게시글 작성',
-      onClick: this.writePostRoute.bind(this),
+      onClick: this.navigateToWritePostRoute.bind(this),
       idName: 'write-button',
     })
   }
 
-  writePostRoute() {
+  navigateToWritePostRoute() {
     navigateTo(ROUTES.POST.WRITE.url)
   }
 }

--- a/pages/post/PostList.js
+++ b/pages/post/PostList.js
@@ -1,3 +1,4 @@
+import Button from '../../components/common/Button/Button.js'
 import Component from '../../components/common/Component.js'
 import { parseDateToFullString } from '../../lib/utils/date.js'
 import { formatNumber } from '../../lib/utils/number.js'
@@ -52,7 +53,7 @@ class PostList extends Component {
           <span>안녕하세요,</span>
           <span>아무 말 대잔치 <strong>게시판</strong>입니다.</span>
         </section>
-        <button id="write-button">게시글 작성</button>
+        <button id="write-button"></button>
         <ul id="posts">
           ${postList}
         </ul>
@@ -65,10 +66,13 @@ class PostList extends Component {
     this.$elements = {
       writePostButton: this.$target.querySelector('#write-button'),
     }
-  }
 
-  setEvent() {
-    this.addEvent('click', this.$elements.writePostButton, this.writePostRoute.bind(this))
+    // 자식 요소 정의
+    new Button(this.$elements.writePostButton, {
+      text: '게시글 작성',
+      onClick: this.writePostRoute.bind(this),
+      idName: 'write-button',
+    })
   }
 
   writePostRoute() {

--- a/pages/post/PostModify.js
+++ b/pages/post/PostModify.js
@@ -1,3 +1,4 @@
+import Button from '../../components/common/Button/Button.js'
 import Component from '../../components/common/Component.js'
 import { ROUTES } from '../../public/data/routes.js'
 import { navigateTo } from '../../router.js'
@@ -38,7 +39,7 @@ class PostModify extends Component {
             <input type="file" id="image-input" accept="image/*" />
           </div>
         </form>
-        <button id="modify-button">수정하기</button>
+        <button id="modify-button"></button>
       </main>
     `
   }
@@ -53,12 +54,17 @@ class PostModify extends Component {
       // 버튼 요소
       modifyButton: this.$target.querySelector('#modify-button'),
     }
+
+    // 자식 요소 정의
+    new Button(this.$elements.modifyButton, {
+      text: '수정하기',
+      onClick: this.modifyPostHandler.bind(this),
+      idName: 'modify-button',
+    })
   }
 
   setEvent() {
     this.addEvent('input', this.$elements.titleInput, this.sliceTitle.bind(this))
-
-    this.addEvent('click', this.$elements.modifyButton, this.modifyPostHandler.bind(this))
   }
 
   /** 제목은 최대 26자 */

--- a/pages/post/PostModify.js
+++ b/pages/post/PostModify.js
@@ -64,7 +64,7 @@ class PostModify extends Component {
   }
 
   setEvent() {
-    this.addEvent('input', this.$elements.titleInput, this.sliceTitle.bind(this))
+    this.addEvent(this.$elements.titleInput, 'input', this.sliceTitle.bind(this))
   }
 
   /** 제목은 최대 26자 */

--- a/pages/post/PostWrite.js
+++ b/pages/post/PostWrite.js
@@ -68,12 +68,12 @@ class PostWrite extends Component {
   }
 
   setEvent() {
-    this.addEvent('input', this.$elements.titleInput, event => {
+    this.addEvent(this.$elements.titleInput, 'input', event => {
       this.validateTitle()
       this.validateForm()
     })
 
-    this.addEvent('input', this.$elements.textareaInput, event => {
+    this.addEvent(this.$elements.textareaInput, 'input', event => {
       this.validateForm()
     })
   }

--- a/pages/post/PostWrite.js
+++ b/pages/post/PostWrite.js
@@ -1,3 +1,4 @@
+import Button from '../../components/common/Button/Button.js'
 import Component from '../../components/common/Component.js'
 import { ROUTES } from '../../public/data/routes.js'
 import { navigateTo } from '../../router.js'
@@ -39,7 +40,7 @@ class PostWrite extends Component {
             <input type="file" id="image-input" accept="image/*" />
           </div>
         </form>
-        <button id="submit-button">완료</button>
+        <button id="submit-button"></button>
       </main>
     `
   }
@@ -57,6 +58,13 @@ class PostWrite extends Component {
       // 버튼 요소
       submitButton: this.$target.querySelector('#submit-button'),
     }
+
+    // 자식 요소 정의
+    new Button(this.$elements.submitButton, {
+      text: '완료',
+      onClick: this.submitPostHandler.bind(this),
+      idName: 'submit-button',
+    })
   }
 
   setEvent() {
@@ -68,8 +76,6 @@ class PostWrite extends Component {
     this.addEvent('input', this.$elements.textareaInput, event => {
       this.validateForm()
     })
-
-    this.addEvent('click', this.$elements.submitButton, this.submitPostHandler.bind(this))
   }
 
   /** 제목은 최대 26자 */

--- a/router.js
+++ b/router.js
@@ -27,14 +27,16 @@ function router(requestedUrl) {
     new Header($header, {
       route: requestedUrl,
     })
+
     // #2. 페이지 컴포넌트 생성
-    new Component($app)
+    new Component($app, {})
   } else {
     /** 정의되지 않은 컴포넌트(페이지) */
     $app.innerHTML = '<h1>404 - Page Not Found</h1>'
   }
 }
 
-window.addEventListener('popstate', () => {
+window.addEventListener('popstate', event => {
+  event.preventDefault()
   navigateTo(window.location.pathname)
 })


### PR DESCRIPTION
# 리펙토링 목록

## Inline 컴포넌트 구현

기존의 인라인 컴포넌트는 `template()`안에서 동적으로 마운팅되기를 원했으나, 이벤트 핸들링 이슈로 인해 방법을 수정하였습니다.
1. 빈 요소를 설정합니다. `<button id="submit-button"></button>`
2. 해당 요소의 자식으로 `Button` 컴포넌트를 마운트시킵니다.
3. 1번에서 생성한 빈 요소를 삭제합니다.

최종적으로 2번에서 마운트시킨 요소만 남습니다.

- `Button.js` 를 인라인 컴포넌트로 구현하여 적용시켰습니다.

<br />
<br />

## Portal 컴포넌트 구현

`Portal` 컴포넌트는 `Toast`, `Modal` 처럼 `body`의 마지막 요소로 들어가는 컴포넌트입니다.


<br />
<br />

## InlineComponent, PortalComponent, Component 공통 로직 추출

3가지 컴포넌트의 공통 로직을 `BaseComponent`로 추출하여 클래스로 구성하였습니다.

<br />
<br />

## 외 

- 가독성을 위해 `addEvent` 함수의 매개변수 순서를 변경합니다.
- 함수들의 네이밍을 구체화합니다. (**라우팅**[`navigateToxxx`]  /  **로직 + 라우팅**[`xxxHandler`])
